### PR TITLE
Ft/1.4 go ffi

### DIFF
--- a/crates/lumina-ffi/lumina_go/README.md
+++ b/crates/lumina-ffi/lumina_go/README.md
@@ -1,0 +1,17 @@
+# Lumina Go Wrapper
+
+This is the Go package for Lumina v1.4, interacting with the `lumina_ffi` shared library via `cgo`.
+
+## Prerequisites
+Build the FFI library first:
+```bash
+cargo build --release -p lumina-ffi
+```
+
+## Running Tests
+Ensure Go can find the shared library at test time:
+```bash
+CGO_LDFLAGS="-L../../../target/release -llumina_ffi" \
+LD_LIBRARY_PATH=../../../target/release \
+go test -v ./...
+```

--- a/crates/lumina-ffi/lumina_go/lumina.go
+++ b/crates/lumina-ffi/lumina_go/lumina.go
@@ -1,0 +1,100 @@
+package lumina
+
+/*
+#cgo linux LDFLAGS: -L../../../target/release -llumina_ffi -Wl,-rpath,../../../target/release
+#cgo darwin LDFLAGS: -L../../../target/release -llumina_ffi
+#include "../lumina.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unsafe"
+)
+
+// Runtime wraps the opaque LuminaRuntime C pointer.
+// Always call Close() when done - it frees the C-side memory.
+type Runtime struct {
+	ptr *C.LuminaRuntime
+}
+
+// FromSource creates a Runtime from a Lumina source string.
+// Returns an error if parsing or analysis fails.
+func FromSource(source string) (*Runtime, error) {
+	cs := C.CString(source)
+	defer C.free(unsafe.Pointer(cs))
+	ptr := C.lumina_create(cs)
+	if ptr == nil {
+		return nil, errors.New("lumina: failed to create runtime (parse/analyze error)")
+	}
+	return &Runtime{ptr: ptr}, nil
+}
+
+// ApplyEvent sets instance.field = value.
+// valueJSON must be a valid JSON-encoded string:
+// Number: "42" or "3.14"
+// Text: "\"hello\"" (extra quotes - it is JSON)
+// Boolean: "true" or "false"
+// Returns the PropResult as a map, or an error on rollback.
+func (r *Runtime) ApplyEvent(instance, field, valueJSON string) (map[string]any, error) {
+	ci := C.CString(instance)
+	cf := C.CString(field)
+	cv := C.CString(valueJSON)
+	defer C.free(unsafe.Pointer(ci))
+	defer C.free(unsafe.Pointer(cf))
+	defer C.free(unsafe.Pointer(cv))
+	raw := C.lumina_apply_event(r.ptr, ci, cf, cv)
+	if raw == nil {
+		return nil, errors.New("lumina: null response from apply_event")
+	}
+	defer C.lumina_free_string(raw)
+	result := C.GoString(raw)
+	// Rollback is signaled by "ERROR:{...}"
+	if strings.HasPrefix(result, "ERROR:") {
+		return nil, fmt.Errorf("lumina rollback: %s", result[6:])
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(result), &out); err != nil {
+		return nil, fmt.Errorf("lumina: cannot parse response: %w", err)
+	}
+	return out, nil
+}
+
+// ExportState returns the full runtime state as a parsed map.
+// Keys: "instances" -> map of instance name -> { "fields": {...} }
+func (r *Runtime) ExportState() (map[string]any, error) {
+	raw := C.lumina_export_state(r.ptr)
+	if raw == nil {
+		return nil, errors.New("lumina: null response from export_state")
+	}
+	defer C.lumina_free_string(raw)
+	var out map[string]any
+	err := json.Unmarshal([]byte(C.GoString(raw)), &out)
+	return out, err
+}
+
+// Tick advances all timers. Returns a slice of fired events.
+// Call on a time.Ticker for every/for rules.
+func (r *Runtime) Tick() ([]map[string]any, error) {
+	raw := C.lumina_tick(r.ptr)
+	if raw == nil {
+		return nil, errors.New("lumina: null response from tick")
+	}
+	defer C.lumina_free_string(raw)
+	var events []map[string]any
+	err := json.Unmarshal([]byte(C.GoString(raw)), &events)
+	return events, err
+}
+
+// Close destroys the runtime and frees all C-side memory.
+// After Close(), the Runtime must not be used.
+func (r *Runtime) Close() {
+	if r.ptr != nil {
+		C.lumina_destroy(r.ptr)
+		r.ptr = nil
+	}
+}

--- a/crates/lumina-ffi/lumina_go/lumina_test.go
+++ b/crates/lumina-ffi/lumina_go/lumina_test.go
@@ -1,0 +1,80 @@
+package lumina_test
+
+import (
+	"testing"
+	lumina "." // import the local package
+)
+
+const basicSource = `
+entity Moto {
+	battery: Number
+	isLowBattery := battery < 20
+}
+let moto1 = Moto { battery: 80 }
+`
+
+func TestFromSource(t *testing.T) {
+	rt, err := lumina.FromSource(basicSource)
+	if err != nil {
+		t.Fatalf("FromSource failed: %v", err)
+	}
+	defer rt.Close()
+}
+
+func TestFromSourceInvalid(t *testing.T) {
+	_, err := lumina.FromSource("this is not valid lumina @@@@")
+	if err == nil {
+		t.Fatal("expected error for invalid source")
+	}
+}
+
+func TestApplyEventAndExportState(t *testing.T) {
+	rt, err := lumina.FromSource(basicSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+	_, err = rt.ApplyEvent("moto1", "battery", "15")
+	if err != nil {
+		t.Fatalf("ApplyEvent failed: %v", err)
+	}
+	state, err := rt.ExportState()
+	if err != nil {
+		t.Fatalf("ExportState failed: %v", err)
+	}
+	instances := state["instances"].(map[string]any)
+	moto1 := instances["moto1"].(map[string]any)
+	fields := moto1["fields"].(map[string]any)
+	isLow := fields["isLowBattery"].(bool)
+	if !isLow {
+		t.Error("expected isLowBattery=true after setting battery=15")
+	}
+}
+
+func TestRollbackOnDerivedField(t *testing.T) {
+	rt, err := lumina.FromSource(basicSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+	_, err = rt.ApplyEvent("moto1", "isLowBattery", "true")
+	if err == nil {
+		t.Fatal("expected rollback error R009 for derived field write")
+	}
+}
+
+func TestTick(t *testing.T) {
+	rt, err := lumina.FromSource(basicSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+	events, err := rt.Tick()
+	if err != nil {
+		t.Fatalf("Tick failed: %v", err)
+	}
+	// No every/for rules in basicSource - events should be empty
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+}

--- a/extensions/lumina-vscode/package.json
+++ b/extensions/lumina-vscode/package.json
@@ -2,8 +2,9 @@
     "name": "lumina-language",
     "displayName": "Lumina",
     "description": "Lumina (.lum) language support - syntax highlighting and snippets",
-    "version": "0.1.0",
+    "version": "0.1.2",
     "publisher": "isaac-ishimwe",
+    "icon": "icon.png",
     "engines": {
         "vscode": "^1.75.0"
     },
@@ -21,6 +22,10 @@
                 "extensions": [
                     ".lum"
                 ],
+                "icon": {
+                    "light": "./icon16.svg",
+                    "dark": "./icon16.svg"
+                },
                 "configuration": "./language-configuration.json"
             }
         ],

--- a/extensions/lumina-vscode/syntaxes/lumina.tmLanguage.json
+++ b/extensions/lumina-vscode/syntaxes/lumina.tmLanguage.json
@@ -7,6 +7,17 @@
             "include": "#comments"
         },
         {
+            "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\()",
+            "name": "entity.name.function.lumina"
+        },
+        {
+            "match": "\\b(fn|entity|rule)\\b\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+            "captures": {
+                "1": { "name": "storage.type.lumina" },
+                "2": { "name": "entity.name.function.lumina" }
+            }
+        },
+        {
             "include": "#strings"
         },
         {
@@ -20,6 +31,12 @@
         },
         {
             "include": "#types"
+        },
+        {
+            "include": "#members"
+        },
+        {
+            "include": "#variables"
         },
         {
             "include": "#operators"
@@ -39,13 +56,21 @@
             "end": "\"",
             "patterns": [
                 {
+                    "name": "constant.character.escape.lumina",
+                    "match": "\\\\."
+                },
+                {
                     "name": "meta.interpolation.lumina",
-                    "begin": "\\\\{",
-                    "end": "\\\\}",
+                    "begin": "\\{",
+                    "beginCaptures": {
+                        "0": { "name": "punctuation.section.embedded.begin.lumina" }
+                    },
+                    "end": "\\}",
+                    "endCaptures": {
+                        "0": { "name": "punctuation.section.embedded.end.lumina" }
+                    },
                     "patterns": [
-                        {
-                            "include": "$self"
-                        }
+                        { "include": "$self" }
                     ]
                 }
             ]
@@ -59,19 +84,51 @@
             "match": "\\b(true|false)\\b"
         },
         "keywords": {
-            "name": "keyword.control.lumina",
-            "match": "\\b(entity|rule|when|becomes|for|every|let|show|update|to|create|delete|if|then|else|and|or|not|is|external|sync|on|fn|import)\\b"
+            "patterns": [
+                {
+                    "name": "keyword.control.lumina",
+                    "match": "\\b(if|then|else|let|import|external|sync|on|is|and|or|not)\\b"
+                },
+                {
+                    "name": "storage.type.lumina",
+                    "match": "\\b(entity|fn|rule)\\b"
+                },
+                {
+                    "name": "keyword.other.reactive.lumina",
+                    "match": "\\b(when|becomes|for|every)\\b"
+                },
+                {
+                    "name": "keyword.other.action.lumina",
+                    "match": "\\b(show|update|to|create|delete)\\b"
+                }
+            ]
         },
         "types": {
-            "name": "storage.type.lumina",
-            "match": "\\b(Number|Text|Boolean)\\b"
+            "patterns": [
+                {
+                    "name": "storage.type.primitive.lumina",
+                    "match": "\\b(Number|Text|Boolean)\\b"
+                },
+                {
+                    "name": "entity.name.type.lumina",
+                    "match": "\\b[A-Z][a-zA-Z0-9_]*\\b"
+                }
+            ]
+        },
+        "members": {
+            "match": "\\b([a-z][a-zA-Z0-9_]*)\\s*(?=:)",
+            "name": "variable.other.member.lumina"
+        },
+        "variables": {
+            "match": "\\b[a-z][a-zA-Z0-9_]*\\b",
+            "name": "variable.other.lumina"
         },
         "operators": {
             "name": "keyword.operator.lumina",
             "match": ":=|->|==|!=|>=|<=|>|<|\\+|-|\\*|/|%|\\.|:"
         },
         "metadata": {
-            "name": "storage.modifier.lumina",
+            "name": "variable.parameter.metadata.lumina",
             "match": "@(range|doc|affects)"
         }
     }


### PR DESCRIPTION
Changes Included: 
**CGO Bridge (lumina.go):** Implemented a Go package wrapping the 6 core C ABI functions from lumina.h.

**Memory Safety:** Added strict defer C.lumina_free_string(raw) calls on all JSON payloads and error strings returned by the FFI to prevent C-side memory leaks.

**Error Handling:** Implemented deep error extraction, translating Rust's ERROR:{...} JSON rollbacks (e.g., R009 derived field writes) into idiomatic error returns in Go.
**Go Test Suite (lumina_test.go):** Included an extensive 5-part test suite verifying:

- **TestFromSource:**  Safe runtime instantiation.
- **TestFromSourceInvalid:** Syntax and analysis error surfacing.
- **TestApplyEventAndExportState:** Successful state mutation and JSON parsing.
- **TestRollbackOnDerivedField:** Validating that reactive rules (e.g., stopping manual writes to derived fields) correctly trigger rollbacks.
- **TestTick:** Executing temporal timer ticks.

**Documentation (README.md):** Added build flags (CGO_LDFLAGS) and usage instructions for successfully linking the FFI during go test and go build.