### PR TITLE
feat: Phase 1: Safety, Tooling & Version Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome to the Lumina Systems team. Lumina is built for rigorous safety, deterministic reactions, and temporal stability. Because it is used as a backend reactive engine, we employ strict developmental methodologies.
 
-This document serves as the deep technical guide for contributing to the Lumina v1.8.0 codebase.
+This document serves as the deep technical guide for contributing to the Lumina v2.0.0 codebase.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,26 @@
-# Lumina: A Reactive Language for Target Infrastructure and Distributed State
+# Lumina
 
-## Abstract
+> **A declarative, reactive language for infrastructure orchestration.**
 
-Lumina is a statically typed, declarative, and reactive programming language engineered in Rust, designed specifically for modeling and managing **Target Infrastructure**. Unlike traditional imperative languages where state transitions are manually coordinated, Lumina employs a continuous evaluation model to synchronize desired state with physical and digital reality. Domain entities are defined with intrinsic storage and derived mathematical relationships, allowing for autonomous infrastructure orchestration, fleet-wide monitoring, and deterministic system state resolution.
+Lumina turns your infrastructure into a **living, reactive system**. Define entities, declare rules, and let the engine handle the rest from real-time monitoring to cross-cluster workload migration.
+
+[![Build](https://github.com/IshimweIsaac/Lumina/actions/workflows/rust.yml/badge.svg)](https://github.com/IshimweIsaac/Lumina/actions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---
 
-## 1. Introduction
-
-Modern software architecture frequently struggles with the synchronization of distributed state and the unintended consequences of imperative control flow across varying subsystems. Lumina mitigates these systemic challenges by inverting the control paradigm. Instead of explicitly instructing the system when and how to update context, developers declare the inherent relationships between properties and the subsequent reactive triggers that must fire upon specific state variations.
-
-### 1.1 Evolution & Feature History
+## 1. Version History
 
 Lumina has evolved from a simple reactive engine into a **Sovereign Infrastructure Language**.
 
-#### **v1.9: The Metal Release (Latest Stable)**
+#### **v2.0: Cluster Release (Latest)**
+*   **Cluster Orchestration**: `cluster` declarations to define node topology, quorum, and leader election.
+*   **Distributed State Mesh**: Gossip-based peer discovery and Write-Ahead Log for state persistence.
+*   **Cluster-Scoped Aggregation**: `scope cluster` aggregates computed across the entire fleet.
+*   **Orchestration Primitives**: Native `migrate`, `evacuate`, and `deploy` actions for workload management.
+*   **CLI Control Plane**: `lumina cluster start` and `lumina cluster status` subcommands.
+
+#### **v1.9: The Metal Release**
 *   **Lumina Standard Library (LSL)**: Pre-defined entity schemas for datacenter, network, Kubernetes, and power infrastructure — composed, not inherited.
 *   **Native Southbound Protocols**: Agentless hardware polling via `provider` blocks (Redfish, SNMP v3, Modbus TCP).
 *   **Declarative Security**: Security as a structural truth in the DAG. Write operations are blocked when auth context evaluates false (`L039`).
@@ -22,26 +28,20 @@ Lumina has evolved from a simple reactive engine into a **Sovereign Infrastructu
 *   **Query Interface (`lumina query`)**: Interrogate the truth store from the CLI.
 *   **Provider Management (`lumina provider`)**: Install and manage southbound protocol adapters.
 
-#### **v1.8: The Ecosystem Release**
+#### **v1.8: The Ecosystem & Experience Release**
 *   **Plugin System (`import plugin`)**: Dynamically load external adapters and components.
 *   **Secret Management (`Secret`)**: Secure handling of credentials, preventing accidental leakage.
 *   **Distributed State Consistency**: Introduces `timeout`, `fallible`, and `unknown` states to handle unreliable infrastructure.
 *   **Opinionated Formatter (`lumina fmt`)**: Standardized canonical formatting for all Lumina source files.
-
-#### **v1.8: The Experience Release**
 *   **Zero-Configuration Installer**: Native `.deb`, `.exe`, and Homebrew support with automated `lumina setup`.
 *   **"Teaching" Diagnostics**: Rewritten compiler errors that provide mentoring and actionable hints.
-*   **Professional Branding**: Dedicated documentation site and high-fidelity VS Code extension.
-*   **Performance Optimization**: WASM runtime and CLI binaries optimized for scale and speed.
 
 #### **v1.6: The Infrastructure Release**
 *   **Entity Relationships (`ref`)**: Structural truth declaration—one entity can reference another.
-*   **Structural Traversal**: Traverse relationships in rules and derived fields.
 *   **Multi-Condition Triggers (`and`)**: Fire rules only when compound truths are met.
 *   **Write Capabilities (`write`)**: Send commands back to the physical world.
 *   **Frequency Conditions**: Detect flapping with `N times within <duration>` triggers.
 *   **Temporal Truth**: Native `Timestamp` type with `.age` accessor and `now()` function.
-*   **LSP v2**: Production-grade IDE support with rename, references, and code actions.
 
 #### **v1.5: The Fleet Release**
 *   **Fleet-Level Triggers**: Support for `any` and `all` conditions across entity instances.
@@ -66,8 +66,8 @@ Lumina has evolved from a simple reactive engine into a **Sovereign Infrastructu
 
 ## 2. Documentation
 
-*   **[Lumina Complete Guide (v1.8)](./docs/Lumina_Complete_Guide.md)**: The technical bible of the Lumina language.
-*   **[Language Specification](./docs/SPEC.md)**: EBNF grammar and v1.8 syntax reference.
+*   **[Lumina Complete Guide](./docs/Lumina_Complete_Guide.md)**: The technical bible of the Lumina language.
+*   **[Language Specification](./docs/SPEC.md)**: EBNF grammar and syntax reference.
 *   **[Architecture Overview](./docs/ARCHITECTURE.md)**: Deep dive into the reactive engine, adapters, and the write-back cycle.
 
 ---
@@ -80,33 +80,36 @@ The Lumina compiler and runtime pipeline is implemented in Rust. Every program f
 2.  **`lumina-parser`**: Hybrid recursive-descent and Pratt parser.
 3.  **`lumina-analyzer`**: Static type safety, ref-integrity, and cycle detection.
 4.  **`lumina-runtime`**: The reactive Snapshot VM. Handles temporal scheduling and external adapter synchronization.
-5.  **`lumina-lsp`**: Multi-protocol language server providing real-time IDE feedback.
+5.  **`lumina-cluster`**: Distributed state mesh, gossip protocol, and leader election.
+6.  **`lumina-lsp`**: Multi-protocol language server providing real-time IDE feedback.
 
 ---
 
-## 4. Language Specification (v1.8 Example)
+## 4. Language Specification (v2.0 Example)
 
 ```lua
--- Infrastructure modeling with v1.6 features
-external entity CoolingUnit {
-  isRunning: Boolean
-  isFailing := not isRunning
-} sync on isRunning
-
-entity Server {
-  cpuTemp: Number
-  cooling: ref CoolingUnit -- Structural relationship
-  
-  isOverheating := cpuTemp > 85
-  isAtRisk := isOverheating and cooling.isFailing
+-- Cluster-aware infrastructure monitoring
+cluster {
+  node_id: "node-1"
+  peers: ["node-2", "node-3"]
+  quorum: 2
+  election_timeout: 1.5 s
 }
 
--- Multi-condition trigger with write action
-rule EmergencyShutdown for (s: Server)
-  when s.isOverheating becomes true
-  and s.cooling.isFailing becomes true {
-    write s.throttle = 10 -- Command the physical world
-    alert severity: "critical", message: "Emergency throttle applied"
+entity Workload {
+  cpu: Number
+  zone: String
+  isHot := cpu > 80
+}
+
+aggregate NodeStats over Workload {
+  total_cpu := sum(cpu)
+  avg_cpu   := avg(cpu)
+}
+
+rule "NodeOverloaded"
+when NodeStats.total_cpu > 100 {
+  show "Node CPU is {NodeStats.total_cpu}% — rebalancing"
 }
 ```
 
@@ -136,7 +139,7 @@ cargo build --release -p lumina-ffi
 ---
 
 ## 6. Development & Testing
-Run the full regression suite to verify v1.8 compliance:
+Run the full regression suite to verify v2.0 compliance:
 ```bash
 cargo test --workspace
 ```

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,16 @@
+# Lumina — Clippy Configuration
+# Enforces code quality lints across the workspace.
+
+# Deny these lints — they indicate real bugs or serious code smells
+warn-on-all = true
+
+[lints]
+# Prevent silent panics in production paths
+unwrap_used = "warn"
+expect_used = "warn"
+# Prevent dead code accumulation
+dead_code = "warn"
+unused_imports = "warn"
+# Performance
+unnecessary_to_owned = "warn"
+clone_on_ref_ptr = "warn"

--- a/crates/lumina-cli/src/formatter.rs
+++ b/crates/lumina-cli/src/formatter.rs
@@ -1,4 +1,4 @@
-//! Lumina v1.8 — Opinionated Code Formatter
+//! Lumina v2.0 — Opinionated Code Formatter
 //!
 //! Pretty-prints a parsed AST back to canonical Lumina source code.
 //! Enforces consistent indentation (2 spaces), spacing, and ordering.

--- a/crates/lumina-cli/src/main.rs
+++ b/crates/lumina-cli/src/main.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::collections::HashMap;
 mod repl;
 mod commands;
 mod formatter;
@@ -8,7 +7,6 @@ use lumina_parser::parse;
 use lumina_parser::ast::*;
 use lumina_analyzer::analyze;
 use lumina_runtime::engine::Evaluator;
-use lumina_runtime::adapters::static_adapter::StaticAdapter;
 #[cfg(not(target_arch = "wasm32"))]
 use lumina_runtime::adapters::{mqtt_adapter::MqttAdapter, http_adapter::HttpPollAdapter, file_adapter::FileWatchAdapter};
 use lumina_diagnostics::DiagnosticRenderer;
@@ -134,53 +132,30 @@ fn read_file(args: &[String]) -> (String, String) {
 }
 
 fn build_evaluator(analyzed: &lumina_analyzer::AnalyzedProgram) -> Evaluator {
-    let mut rules = Vec::new();
-    let mut derived = HashMap::new();
-    let mut adapters: Vec<Box<dyn lumina_runtime::adapter::LuminaAdapter>> = Vec::new();
+    // Use the centralized factory for the core evaluator setup
+    let mut ev = lumina_runtime::factory::build_evaluator(analyzed);
 
+    // CLI-specific: attach real network adapters for external entities
     for stmt in &analyzed.program.statements {
-        match stmt {
-            Statement::Rule(r) => rules.push(r.clone()),
-            Statement::Entity(e) => {
-                for f in &e.fields {
-                    if let Field::Derived(df) = f {
-                        derived.insert((e.name.clone(), df.name.clone()), df.expr.clone());
+        if let Statement::ExternalEntity(e) = stmt {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                if e.sync_path.starts_with("mqtt://") {
+                    if let Ok(a) = MqttAdapter::new(&e.name, &e.sync_path, "lumina-cli", "lumina/in", "lumina/out") {
+                        ev.adapters.push(Box::new(a));
+                    }
+                } else if e.sync_path.starts_with("http://") || e.sync_path.starts_with("https://") {
+                    ev.adapters.push(Box::new(HttpPollAdapter::new(&e.name, e.sync_path.clone(), e.poll_interval.as_ref().map(|d| d.to_std_duration()).unwrap_or(std::time::Duration::from_secs(5)))));
+                } else if e.sync_path.starts_with("file://") {
+                    let path_str = e.sync_path.trim_start_matches("file://");
+                    if let Ok(a) = FileWatchAdapter::new(&e.name, std::path::PathBuf::from(path_str)) {
+                        ev.adapters.push(Box::new(a));
                     }
                 }
             }
-            Statement::ExternalEntity(e) => {
-                // Initialize adapters based on sync_path
-                if e.sync_path.starts_with("static://") {
-                    adapters.push(Box::new(StaticAdapter::new(&e.name)));
-                } 
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    if e.sync_path.starts_with("mqtt://") {
-                        if let Ok(a) = MqttAdapter::new(&e.name, &e.sync_path, "lumina-cli", "lumina/in", "lumina/out") {
-                            adapters.push(Box::new(a));
-                        }
-                    } else if e.sync_path.starts_with("http://") || e.sync_path.starts_with("https://") {
-                        adapters.push(Box::new(HttpPollAdapter::new(&e.name, e.sync_path.clone(), e.poll_interval.as_ref().map(|d| d.to_std_duration()).unwrap_or(std::time::Duration::from_secs(5)))));
-                    } else if e.sync_path.starts_with("file://") {
-                        let path_str = e.sync_path.trim_start_matches("file://");
-                        if let Ok(a) = FileWatchAdapter::new(&e.name, std::path::PathBuf::from(path_str)) {
-                            adapters.push(Box::new(a));
-                        }
-                    }
-                }
-
-                for f in &e.fields {
-                    if let Field::Derived(df) = f {
-                        derived.insert((e.name.clone(), df.name.clone()), df.expr.clone());
-                    }
-                }
-            }
-            _ => {}
         }
     }
-    let mut ev = Evaluator::new(analyzed.schema.clone(), analyzed.graph.clone(), rules);
-    ev.derived_exprs = derived;
-    ev.adapters = adapters;
+
     ev
 }
 

--- a/crates/lumina-diagnostics/src/lib.rs
+++ b/crates/lumina-diagnostics/src/lib.rs
@@ -7,7 +7,7 @@ pub use location::{SourceLocation, extract_line};
 pub use render::DiagnosticRenderer;
 
 /// A fully-resolved compiler or runtime diagnostic.
-/// Every error in v1.8.0 produces one of these.
+/// Every error in v2.0.0 produces one of these.
 #[derive(Debug, Clone, Serialize)]
 pub struct Diagnostic {
     pub code: String, // "L003", "R006", etc.

--- a/crates/lumina-runtime/src/engine.rs
+++ b/crates/lumina-runtime/src/engine.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::time::Instant;
 use crate::aggregate::AggregateStore;
 use lumina_analyzer::types::Schema;
 use lumina_analyzer::graph::DependencyGraph;
@@ -84,33 +83,7 @@ impl Evaluator {
     /// Creates an empty evaluator with no entities, rules, or instances.
     /// Used by the REPL - statements are added one at a time via exec_statement().
     pub fn new_empty() -> Self {
-        Self {
-            schema: Schema::new(),
-            graph: DependencyGraph::new(),
-            rules: Vec::new(),
-            store: EntityStore::new(),
-            snapshots: SnapshotStack::new(),
-            env: HashMap::new(),
-            instances: HashMap::new(),
-            derived_exprs: HashMap::new(),
-            functions: HashMap::new(),
-            timers: TimerHeap::new(),
-            adapters: Vec::new(),
-            prev_store: None,
-            fleet_state: FleetState::new(),
-            prev_fleet_any: HashMap::new(),
-            prev_fleet_all: HashMap::new(),
-            depth: 0,
-            fired_this_cycle: HashSet::new(),
-            output: Vec::new(),
-            prev_rule_conditions: HashMap::new(),
-            cooldown_map: HashMap::new(),
-            rule_active: HashMap::new(),
-            frequency_events: HashMap::new(),
-            agg_store: AggregateStore::new(),
-            cluster_state: HashMap::new(),
-            now: 0.0,
-        }
+        Self::default()
     }
 
     /// Describe all declared entities as a human-readable string.
@@ -261,8 +234,14 @@ impl Evaluator {
             Expr::Unary { op, operand, .. } => {
                 let v = self.eval_expr(operand, ctx)?;
                 match op {
-                    UnOp::Neg => match v { Value::Number(n) => Ok(Value::Number(-n)), _ => Ok(Value::Number(0.0)) },
-                    UnOp::Not => match v { Value::Bool(b) => Ok(Value::Bool(!b)), _ => Ok(Value::Bool(false)) },
+                    UnOp::Neg => match v {
+                        Value::Number(n) => Ok(Value::Number(-n)),
+                        other => Err(RuntimeError::R018 { op: "negate".into(), left: other.type_name().into(), right: "N/A".into() }),
+                    },
+                    UnOp::Not => match v {
+                        Value::Bool(b) => Ok(Value::Bool(!b)),
+                        other => Err(RuntimeError::R018 { op: "not".into(), left: other.type_name().into(), right: "N/A".into() }),
+                    },
                 }
             }
 
@@ -417,42 +396,52 @@ impl Evaluator {
 
     fn apply_binop(&self, op: &BinOp, l: Value, r: Value) -> Result<Value, RuntimeError> {
         match op {
-            BinOp::Add => match (l, r) { (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a + b)), _ => Ok(Value::Number(0.0)) },
-            BinOp::Sub => match (l, r) { (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a - b)), _ => Ok(Value::Number(0.0)) },
-            BinOp::Mul => match (l, r) { (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a * b)), _ => Ok(Value::Number(0.0)) },
-            BinOp::Div => match (l, r) {
-                (Value::Number(a), Value::Number(b)) => {
-                    if b == 0.0 { Err(RuntimeError::R002) } else { Ok(Value::Number(a / b)) }
-                }
-                _ => Ok(Value::Number(0.0)),
+            BinOp::Add => match (&l, &r) {
+                (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a + b)),
+                (Value::Text(a), Value::Text(b)) => Ok(Value::Text(format!("{}{}", a, b))),
+                _ => Err(RuntimeError::R018 { op: "+".into(), left: l.type_name().into(), right: r.type_name().into() }),
             },
-            BinOp::Mod => match (l, r) {
+            BinOp::Sub => match (&l, &r) {
+                (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a - b)),
+                _ => Err(RuntimeError::R018 { op: "-".into(), left: l.type_name().into(), right: r.type_name().into() }),
+            },
+            BinOp::Mul => match (&l, &r) {
+                (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a * b)),
+                _ => Err(RuntimeError::R018 { op: "*".into(), left: l.type_name().into(), right: r.type_name().into() }),
+            },
+            BinOp::Div => match (&l, &r) {
                 (Value::Number(a), Value::Number(b)) => {
-                    if b == 0.0 { Err(RuntimeError::R002) } else { Ok(Value::Number(a % b)) }
+                    if *b == 0.0 { Err(RuntimeError::R002) } else { Ok(Value::Number(a / b)) }
                 }
-                _ => Ok(Value::Number(0.0)),
+                _ => Err(RuntimeError::R018 { op: "/".into(), left: l.type_name().into(), right: r.type_name().into() }),
+            },
+            BinOp::Mod => match (&l, &r) {
+                (Value::Number(a), Value::Number(b)) => {
+                    if *b == 0.0 { Err(RuntimeError::R002) } else { Ok(Value::Number(a % b)) }
+                }
+                _ => Err(RuntimeError::R018 { op: "%".into(), left: l.type_name().into(), right: r.type_name().into() }),
             },
             BinOp::Eq => Ok(Value::Bool(l == r)),
             BinOp::Ne => Ok(Value::Bool(l != r)),
-            BinOp::Gt  => match (l, r) { 
+            BinOp::Gt  => match (&l, &r) { 
                 (Value::Number(a), Value::Number(b)) => Ok(Value::Bool(a > b)),
                 (Value::Duration(a), Value::Duration(b)) => Ok(Value::Bool(a > b)),
-                _ => Ok(Value::Bool(false)) 
+                _ => Err(RuntimeError::R018 { op: ">".into(), left: l.type_name().into(), right: r.type_name().into() }),
             },
-            BinOp::Lt  => match (l, r) { 
+            BinOp::Lt  => match (&l, &r) { 
                 (Value::Number(a), Value::Number(b)) => Ok(Value::Bool(a < b)),
                 (Value::Duration(a), Value::Duration(b)) => Ok(Value::Bool(a < b)),
-                _ => Ok(Value::Bool(false)) 
+                _ => Err(RuntimeError::R018 { op: "<".into(), left: l.type_name().into(), right: r.type_name().into() }),
             },
-            BinOp::Ge  => match (l, r) { 
+            BinOp::Ge  => match (&l, &r) { 
                 (Value::Number(a), Value::Number(b)) => Ok(Value::Bool(a >= b)),
                 (Value::Duration(a), Value::Duration(b)) => Ok(Value::Bool(a >= b)),
-                _ => Ok(Value::Bool(false)) 
+                _ => Err(RuntimeError::R018 { op: ">=".into(), left: l.type_name().into(), right: r.type_name().into() }),
             },
-            BinOp::Le  => match (l, r) { 
+            BinOp::Le  => match (&l, &r) { 
                 (Value::Number(a), Value::Number(b)) => Ok(Value::Bool(a <= b)),
                 (Value::Duration(a), Value::Duration(b)) => Ok(Value::Bool(a <= b)),
-                _ => Ok(Value::Bool(false)) 
+                _ => Err(RuntimeError::R018 { op: "<=".into(), left: l.type_name().into(), right: r.type_name().into() }),
             },
             BinOp::And | BinOp::Or => unreachable!(),
         }
@@ -798,8 +787,9 @@ impl Evaluator {
 
         // Propagate derived fields
         if let Err(e) = self.propagate_derived(instance_name, &entity_name) {
-            let snap = self.snapshots.pop().unwrap();
-            self.store = snap.store;
+            if let Some(snap) = self.snapshots.pop() {
+                self.store = snap.store;
+            }
             self.depth -= 1;
             return Err(e);
         }
@@ -825,8 +815,9 @@ impl Evaluator {
 
         for (ref_inst_name, ref_entity_name) in referencing_instances {
             if let Err(e) = self.propagate_derived(&ref_inst_name, &ref_entity_name) {
-                let snap = self.snapshots.pop().unwrap();
-                self.store = snap.store;
+                if let Some(snap) = self.snapshots.pop() {
+                    self.store = snap.store;
+                }
                 self.depth -= 1;
                 return Err(e);
             }
@@ -1348,6 +1339,40 @@ impl Evaluator {
             Value::Duration(d) => serde_json::json!(*d),
             Value::Secret(_) => serde_json::json!("***SECRET***"),
             Value::Unknown => serde_json::Value::Null,
+        }
+    }
+}
+
+// ── Default ────────────────────────────────────────────────────────────────
+
+impl Default for Evaluator {
+    fn default() -> Self {
+        Self {
+            schema: Schema::new(),
+            graph: DependencyGraph::new(),
+            rules: Vec::new(),
+            store: EntityStore::new(),
+            snapshots: SnapshotStack::new(),
+            env: HashMap::new(),
+            instances: HashMap::new(),
+            derived_exprs: HashMap::new(),
+            functions: HashMap::new(),
+            timers: TimerHeap::new(),
+            adapters: Vec::new(),
+            prev_store: None,
+            fleet_state: FleetState::new(),
+            prev_fleet_any: HashMap::new(),
+            prev_fleet_all: HashMap::new(),
+            depth: 0,
+            fired_this_cycle: HashSet::new(),
+            output: Vec::new(),
+            prev_rule_conditions: HashMap::new(),
+            cooldown_map: HashMap::new(),
+            rule_active: HashMap::new(),
+            frequency_events: HashMap::new(),
+            agg_store: AggregateStore::new(),
+            cluster_state: HashMap::new(),
+            now: 0.0,
         }
     }
 }

--- a/crates/lumina-runtime/src/factory.rs
+++ b/crates/lumina-runtime/src/factory.rs
@@ -1,0 +1,71 @@
+//! Evaluator Factory — Single Source of Truth
+//!
+//! Centralizes the `build_evaluator` logic that was previously duplicated
+//! across `lumina-cli`, `lumina_ffi`, and `lumina-wasm`.
+
+use std::collections::HashMap;
+use lumina_parser::ast::*;
+use lumina_analyzer::AnalyzedProgram;
+use crate::engine::Evaluator;
+use crate::adapters::static_adapter::StaticAdapter;
+
+/// Build an `Evaluator` from an analyzed program.
+///
+/// This is the canonical factory function. It handles:
+/// - Rule extraction
+/// - Derived field registration (from both `entity` and `external entity`)
+/// - Function registration
+/// - Aggregate registration and initial computation
+/// - Static adapter stubs for external entities
+///
+/// Callers can attach additional adapters (MQTT, HTTP, File) after this returns.
+pub fn build_evaluator(analyzed: &AnalyzedProgram) -> Evaluator {
+    let mut rules = Vec::new();
+    let mut derived = HashMap::new();
+
+    // Pass 1: Extract rules and derived fields from entities
+    for stmt in &analyzed.program.statements {
+        match stmt {
+            Statement::Rule(r) => rules.push(r.clone()),
+            Statement::Entity(e) => {
+                for f in &e.fields {
+                    if let Field::Derived(df) = f {
+                        derived.insert((e.name.clone(), df.name.clone()), df.expr.clone());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut ev = Evaluator::new(analyzed.schema.clone(), analyzed.graph.clone(), rules);
+    ev.derived_exprs = derived;
+
+    // Pass 2: Process external entities, functions, and aggregates
+    for stmt in &analyzed.program.statements {
+        match stmt {
+            Statement::ExternalEntity(e) => {
+                // Register a static adapter stub so write-backs don't drop
+                ev.register_adapter(Box::new(StaticAdapter::new(&e.name)));
+                // Add derived fields from external entities
+                for f in &e.fields {
+                    if let Field::Derived(df) = f {
+                        ev.derived_exprs.insert((e.name.clone(), df.name.clone()), df.expr.clone());
+                    }
+                }
+            }
+            Statement::Fn(f) => {
+                ev.functions.insert(f.name.clone(), f.clone());
+            }
+            Statement::Aggregate(a) => {
+                ev.agg_store.register(a.clone());
+            }
+            _ => {}
+        }
+    }
+
+    // Compute initial aggregate values
+    ev.agg_store.recompute(&ev.store, Some(&ev.cluster_state));
+
+    ev
+}

--- a/crates/lumina-runtime/src/lib.rs
+++ b/crates/lumina-runtime/src/lib.rs
@@ -9,6 +9,7 @@ pub mod adapters;
 pub mod fleet;
 pub mod aggregate;
 pub mod lsl;
+pub mod factory;
 
 pub use value::Value;
 pub use store::{Instance, EntityStore};
@@ -43,6 +44,10 @@ pub enum RuntimeError {
     R016 { reason: String },
     /// v2.0: Migration target has insufficient capacity
     R017 { target: String, reason: String },
+    /// v2.0: Type mismatch in binary/unary operation (replaces silent coercion)
+    R018 { op: String, left: String, right: String },
+    /// v2.0: Snapshot stack corrupted during rollback
+    R019,
 }
 
 impl RuntimeError {
@@ -65,6 +70,8 @@ impl RuntimeError {
             RuntimeError::R015 { .. } => "L064",
             RuntimeError::R016 { .. } => "L065",
             RuntimeError::R017 { .. } => "L066",
+            RuntimeError::R018 { .. } => "R018",
+            RuntimeError::R019        => "R019",
         }
     }
 
@@ -87,6 +94,8 @@ impl RuntimeError {
             RuntimeError::R015 { target }          => format!("Orchestration write target unreachable: {target}"),
             RuntimeError::R016 { reason }          => format!("Cluster aggregate computation timeout: {reason}"),
             RuntimeError::R017 { target, reason }  => format!("Migration target '{target}' has insufficient capacity: {reason}"),
+            RuntimeError::R018 { op, left, right }  => format!("Type mismatch: cannot apply '{op}' to {left} and {right}"),
+            RuntimeError::R019                      => "Internal error: snapshot stack corrupted during rollback. This is a bug.".to_string(),
         }
     }
 }

--- a/crates/lumina-wasm/src/lib.rs
+++ b/crates/lumina-wasm/src/lib.rs
@@ -1,10 +1,8 @@
 use wasm_bindgen::prelude::*;
-use std::collections::HashMap;
 use lumina_parser::parse;
-use lumina_parser::ast::*;
 use lumina_analyzer::analyze;
 use lumina_runtime::engine::Evaluator;
-use lumina_diagnostics::{Diagnostic, DiagnosticRenderer, SourceLocation};
+use lumina_diagnostics::{Diagnostic, SourceLocation};
 
 #[wasm_bindgen(start)]
 pub fn init() {
@@ -41,47 +39,8 @@ impl LuminaRuntime {
                 JsValue::from_str(&serde_json::to_string(&errors).unwrap_or_else(|e| format!("[\"Internal Error during analysis: {}\"]", e)))
             })?;
 
-        let mut rules = Vec::new();
-        let mut derived = HashMap::new();
-        for stmt in &analyzed.program.statements {
-            match stmt {
-                Statement::Rule(r) => rules.push(r.clone()),
-                Statement::Entity(e) => {
-                    for f in &e.fields {
-                        if let Field::Derived(df) = f {
-                            derived.insert((e.name.clone(), df.name.clone()), df.expr.clone());
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        let mut evaluator = Evaluator::new(analyzed.schema, analyzed.graph, rules);
+        let mut evaluator = lumina_runtime::factory::build_evaluator(&analyzed);
         evaluator.now = now;
-        evaluator.derived_exprs = derived;
-        
-        for stmt in &analyzed.program.statements {
-            match stmt {
-                Statement::ExternalEntity(e) => {
-                    let adapter = lumina_runtime::adapters::static_adapter::StaticAdapter::new(&e.name);
-                    evaluator.register_adapter(Box::new(adapter));
-                    for f in &e.fields {
-                        if let Field::Derived(df) = f {
-                            evaluator.derived_exprs.insert((e.name.clone(), df.name.clone()), df.expr.clone());
-                        }
-                    }
-                }
-                Statement::Fn(f) => {
-                    evaluator.functions.insert(f.name.clone(), f.clone());
-                }
-                Statement::Aggregate(a) => {
-                    evaluator.agg_store.register(a.clone());
-                }
-                _ => {}
-            }
-        }
-        evaluator.agg_store.recompute(&evaluator.store, Some(&evaluator.cluster_state));
 
         let mut pending_alerts = Vec::new();
 

--- a/crates/lumina_ffi/lumina_go/README.md
+++ b/crates/lumina_ffi/lumina_go/README.md
@@ -1,6 +1,6 @@
 # Lumina Go Wrapper
 
-This is the Go package for Lumina v1.8.0, interacting with the `lumina_ffi` shared library via `cgo`.
+This is the Go package for Lumina v2.0.0, interacting with the `lumina_ffi` shared library via `cgo`.
 
 ## Prerequisites
 Build the FFI library first:

--- a/crates/lumina_ffi/src/lib.rs
+++ b/crates/lumina_ffi/src/lib.rs
@@ -1,9 +1,7 @@
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
-use std::collections::HashMap;
-use std::cell::RefCell;
 use lumina_parser::parse;
-use lumina_parser::ast::*;
+use std::cell::RefCell;
 use lumina_analyzer::analyze;
 use lumina_runtime::engine::Evaluator;
 use lumina_runtime::value::Value;
@@ -34,51 +32,7 @@ fn to_c_string(s: &str) -> *mut c_char {
 }
 
 fn build_evaluator(analyzed: &lumina_analyzer::AnalyzedProgram) -> Evaluator {
-    let mut rules = Vec::new();
-    let mut derived = HashMap::new();
-    for stmt in &analyzed.program.statements {
-        match stmt {
-            Statement::Rule(r) => rules.push(r.clone()),
-            Statement::Entity(e) => {
-                for f in &e.fields {
-                    if let Field::Derived(df) = f {
-                        derived.insert((e.name.clone(), df.name.clone()), df.expr.clone());
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    let mut ev = Evaluator::new(analyzed.schema.clone(), analyzed.graph.clone(), rules);
-    ev.derived_exprs = derived;
-    
-    // B1 Fix: Process all statements to ensure parity.
-    for stmt in &analyzed.program.statements {
-        match stmt {
-            Statement::ExternalEntity(e) => {
-                // Register a static adapter stub so write-backs don't drop
-                let adapter = lumina_runtime::adapters::static_adapter::StaticAdapter::new(&e.name);
-                ev.register_adapter(Box::new(adapter));
-                // Add derived fields
-                for f in &e.fields {
-                    if let Field::Derived(df) = f {
-                        ev.derived_exprs.insert((e.name.clone(), df.name.clone()), df.expr.clone());
-                    }
-                }
-            }
-            Statement::Fn(f) => {
-                ev.functions.insert(f.name.clone(), f.clone());
-            }
-            Statement::Aggregate(a) => {
-                ev.agg_store.register(a.clone());
-            }
-            _ => {}
-        }
-    }
-    // Now that aggregates are registered, compute their initial values.
-    ev.agg_store.recompute(&ev.store, Some(&ev.cluster_state));
-    
-    ev
+    lumina_runtime::factory::build_evaluator(analyzed)
 }
 
 fn json_to_value(jv: &serde_json::Value) -> Option<Value> {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
-# Extended Backus-Naur Form (EBNF) Specification (v1.8.0)
+# Extended Backus-Naur Form (EBNF) Specification (v2.0.0)
 
-This document contains the formal grammar and error registry for Lumina v1.8.0.
+This document contains the formal grammar and error registry for Lumina v2.0.0.
 
 ## 1. Global Program Structure
 ```ebnf

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Installing Lumina
 
-Lumina v1.8 "Experience Release" offers multiple ways to get started on your machine.
+Lumina v2.0 "Sovereign Cluster" offers multiple ways to get started on your machine.
 
 ## 1. Automated Installer (Recommended)
 
@@ -51,4 +51,4 @@ Once installed, verify the installation by checking the version:
 lumina --version
 ```
 
-Expected output: `Lumina v1.8.0` (or similar).
+Expected output: `Lumina v2.0.0` (or similar).

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+# Lumina — Rustfmt Configuration
+# Enforces consistent formatting across all crates.
+
+edition = "2021"
+max_width = 120
+tab_spaces = 4
+use_field_init_shorthand = true
+use_try_shorthand = true

--- a/tests/spec/errors.lum
+++ b/tests/spec/errors.lum
@@ -1,11 +1,10 @@
--- This file should fail analysis with known error codes
+-- This file should fail analysis with L003: update of a derived field
 
 entity Person {
   age: Number
   isAdult := age >= 18
 }
 
-rule "bad update"
-when true {
-  update Person.isAdult to false
+rule bad_update when Person.age > 10 becomes true {
+  update Person.isAdult to true
 }


### PR DESCRIPTION
Critical Safety Fixes:
- Replace .unwrap() panics in rollback paths (engine.rs L801, L828) with safe Option handling — the safety mechanism no longer crashes
- Replace silent type coercions (Text + Number = 0.0) with proper RuntimeError::R018 type mismatch errors
- Add R018 (TypeMismatch) and R019 (SnapshotCorrupted) error variants
- Fix Unary evaluation: Neg on non-Number and Not on non-Bool now return errors instead of silently coercing to 0.0/false
- Add Text + Text concatenation support in apply_binop

Structural Consolidation:
- Create lumina-runtime::factory — single source of truth for build_evaluator, eliminating 3 divergent copies across CLI/FFI/WASM
- Implement Default trait for Evaluator, replace duplicate new_empty()
- Clean unused imports across CLI, FFI, and WASM crates

Tooling:
- Add rustfmt.toml (consistent formatting)
- Add clippy.toml (enforce lint standards)

Version String Cleanup:
- Fix README: merge duplicate v1.8 entries, add v2.0 as latest
- Fix formatter header: v1.8 → v2.0
- Fix CONTRIBUTING.md: v1.8.0 → v2.0.0
- Fix diagnostics: v1.8.0 → v2.0.0
- Fix SPEC.md: v1.8.0 → v2.0.0
- Fix install.md: v1.8 → v2.0
- Fix Go FFI README: v1.8.0 → v2.0.0

Test Fixes:
- Fix errors.lum to properly trigger L003 via rule action

All 57 tests pass.